### PR TITLE
Automated benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 benchmarks/
 single-benchmark.zip
 *.pyc
+
+venv/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Computer Architecture Simulation Infrastructure for CSCE 614 Computer Architecture
 
 
-##### 1. Unzip benchmarks files
+### 1. Unzip benchmarks files
 
 ```
 zip -F benchmarks.zip --out single-benchmark.zip && unzip single-benchmark.zip && mkdir benchmarks/parsec-2.1/inputs/streamcluster
@@ -25,15 +25,78 @@ $ source venv/bin/activate
 $ source setup_env
 ```
 
-##### 3. Compile zsim
+### 3. Compile zsim
 
 ```
 $ cd zsim
 $ scons -j4
 ```
 
-You need to compile the code each time you make a change.
+You need to compile the code each time you make a change. However, keep in mind that the build scripts detailed below will rebuild zsim each time you run them.
 
+### 4. Running Benchmarks
 
+There are two different programs that allow you to run the benchmarks: a shell script titled `hw4runscript` and a .cpp program titled `hw4runpolicy.cpp`. Instructions on how to run these are detailed below.
+
+#### 4a. hw4runscript 
+
+The `hw4runscript` is a shell script that tests a single replacement policy on a single benchmark. The correct usage of the file is as follows:
+```
+$ ./hw4runscript <suite> <benchmark> <repl_policy> &
+```
+where
+```
+    (suite) benchmarks: 
+        -- (SPEC) bzip2 gcc mcf hmmer sjeng libquantum xalancbmk milc cactusADM leslie3d namd soplex calculix lbm
+        -- (PARSEC) blackscholes bodytrack canneal dedup fluidanimate freqmine streamcluster swaptions x264
+    repl_policy: LRU LFU SRRIP
+```
+The `&` is used so that the script can be run as a background process and you can continue to use the terminal. However, it is recommended to use `tmux`, a terminal multiplexer, to run the benchmarks. More details are below in 4c.
+
+#### 4b. hw4runpolicy.cpp
+
+The `hw4runpolicy.cpp` is a .cpp program that tests a single replacement policy on all the benchmarks required for this homework. The correct usage of the file is as follows:
+```
+$ g++ -std=c++17 -Wall -Wextra -Wpedantic -o hw4runpolicy.o hw4runpolicy.cpp
+$ ./hw4runpolicy.o -r <repl_policy> [-n <max_running_processes>] &
+```
+where
+```
+    repl_policy: LRU LFU SRRIP
+    (optional) max_running_processes: >= 1 (set to 1 by default)
+```
+Once again, the `&` is used so the script can be run as a background process. 
+
+One thing to note is that the `<max_running_processes>` should be changed with EXTREME CAUTION. Ensure that you check with your system administrator to ensure you do not take up too many resources.
+
+#### 4c. Using tmux
+
+It is recommended that you use `tmux`, a terminal multiplexer, to run the benchmarks so that the benchmarks continue to run even if you are disconnected from your session.
+
+Examples of how you would use `tmux` for running both the `hw4runscript` and the `hw4runpolicy.cpp` are shown below. Keep in mind that the naming conventions used in the examples are optional; however, make sure you don't recompile and accidentally overwrite an existing executable that is running.
+
+##### hw4runpolicy.cpp with tmux
+```
+$ tmux new -s run_<repl_policy>_<benchmark>
+$ ./hw4runscript <suite> <benchmark> <repl_policy> &
+```
+
+##### hw4runpolicy.cpp with tmux
+```
+$ tmux new -s run_<repl_policy>
+$ g++ -std=c++17 -Wall -Wextra -Wpedantic -o hw4runpolicy_<repl_policy>.o hw4runpolicy.cpp 
+$ ./hw4runpolicy_<repl_policy>.o -r <repl_policy> -n <max_running_processes> &
+```
+To exit out of the `tmux` session: <kbd>Ctrl</kbd> + <kbd>b</kbd>, <kbd>d</kbd>
+
+To see the `tmux` sessions you have up, simply do:
+```
+tmux ls
+```
+
+To check on the benchmarks running in a `tmux` session, simply reconnect to the window of your choosing
+```
+tmux attach-session -t <session_name>
+```
 
 ###### For more information, check `zsim/README.md`

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ $ ./hw4runscript <suite> <benchmark> <repl_policy> &
 ```
 where
 ```
-    (suite) benchmarks: 
-        -- (SPEC) bzip2 gcc mcf hmmer sjeng libquantum xalancbmk milc cactusADM leslie3d namd soplex calculix lbm
-        -- (PARSEC) blackscholes bodytrack canneal dedup fluidanimate freqmine streamcluster swaptions x264
-    repl_policy: LRU LFU SRRIP
+(suite) benchmarks: 
+    -- (SPEC) bzip2 gcc mcf hmmer sjeng libquantum xalancbmk milc cactusADM leslie3d namd soplex calculix lbm
+    -- (PARSEC) blackscholes bodytrack canneal dedup fluidanimate freqmine streamcluster swaptions x264
+repl_policy: LRU LFU SRRIP
 ```
 The `&` is used so that the script can be run as a background process and you can continue to use the terminal. However, it is recommended to use `tmux`, a terminal multiplexer, to run the benchmarks. More details are below in 4c.
 
@@ -62,8 +62,8 @@ $ ./hw4runpolicy.o -r <repl_policy> [-n <max_running_processes>] &
 ```
 where
 ```
-    repl_policy: LRU LFU SRRIP
-    (optional) max_running_processes: >= 1 (set to 1 by default)
+repl_policy: LRU LFU SRRIP
+(optional) max_running_processes: >= 1 (set to 1 by default)
 ```
 Once again, the `&` is used so the script can be run as a background process. 
 
@@ -75,7 +75,7 @@ It is recommended that you use `tmux`, a terminal multiplexer, to run the benchm
 
 Examples of how you would use `tmux` for running both the `hw4runscript` and the `hw4runpolicy.cpp` are shown below. Keep in mind that the naming conventions used in the examples are optional; however, make sure you don't recompile and accidentally overwrite an existing executable that is running.
 
-##### hw4runpolicy.cpp with tmux
+##### hw4runscript with tmux
 ```
 $ tmux new -s run_<repl_policy>_<benchmark>
 $ ./hw4runscript <suite> <benchmark> <repl_policy> &

--- a/zsim/hw4runpolicy.cpp
+++ b/zsim/hw4runpolicy.cpp
@@ -1,0 +1,137 @@
+#include <iostream>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <vector>
+#include <unordered_map>
+#include <set>
+#include <string>
+
+size_t MAX_RUNNING_PROCESSES = 1; // declared with a default value of 1
+
+void start_stop_processes(std::vector<pid_t> &child_pids, std::unordered_map<pid_t, const char *> &pid_benchmark_map,
+                          const char **benchmarks, int num_benchmarks, char *benchmark_suite, const char *repl_policy)
+{
+    int child_status;
+
+    for (int i = 0; i < num_benchmarks; ++i)
+    {
+        int pid = fork();
+
+        if (pid != 0)
+        { // if it is the parent, then we want to collect the child pid and wait until it his sigstop
+            child_pids.push_back(pid);
+            pid_benchmark_map[pid] = benchmarks[i];
+            waitpid(pid, &child_status, WUNTRACED);
+        }
+        else
+        { // stop the child process -> we only want the processes in the queue to run
+            std::cout << "Stopping process for: " << benchmarks[i] << ", with pid: " << getpid() << std::endl;
+            raise(SIGSTOP);
+            char *args[] = {const_cast<char *>("./hw4runscript"),
+                            const_cast<char *>(benchmark_suite),
+                            const_cast<char *>(benchmarks[i]),
+                            const_cast<char *>(repl_policy),
+                            NULL};
+            execvp(args[0], args);
+        }
+    }
+}
+
+void restart_processes(std::vector<pid_t> &child_pids, std::unordered_map<pid_t, const char *> pid_benchmark_map)
+{
+    std::set<pid_t> running_pids;
+    int child_status;
+
+    while (!child_pids.empty() || !running_pids.empty())
+    {
+        while (!child_pids.empty() && (running_pids.size() < MAX_RUNNING_PROCESSES))
+        {
+            pid_t stopped_pid = child_pids.back();
+            child_pids.pop_back();
+
+            kill(stopped_pid, SIGCONT); // restart the child process
+            std::cout << "Running benchmark " << pid_benchmark_map[stopped_pid];
+            std::cout << " with pid " << stopped_pid << std::endl;
+
+            running_pids.insert(stopped_pid);
+        }
+
+        pid_t finished_pid = waitpid(-1, &child_status, 0);
+        if (finished_pid > 0)
+        {
+            std::cout << "Finished benchmark " << pid_benchmark_map[finished_pid];
+            std::cout << " with pid " << finished_pid << std::endl;
+            running_pids.erase(finished_pid);
+        }
+    }
+}
+
+int main(int argc, char **argv)
+{
+    std::set<std::string> repl_policies = {"LRU", "LFU", "SRRIP"};
+    int opt;
+    const char *repl_policy = "";
+
+    while ((opt = getopt(argc, argv, "r:n:")) != -1)
+    {
+        switch (opt)
+        {
+        case 'r':
+            repl_policy = optarg;
+            break;
+        case 'n':
+            MAX_RUNNING_PROCESSES = std::atoi(optarg);
+            break;
+        }
+    }
+
+    // check to make sure inputs are correct, also catches if the replacement policy was not declared
+    if (MAX_RUNNING_PROCESSES < 1 || (repl_policies.find(repl_policy) == repl_policies.end()))
+    {
+        std::cerr << "Usage: " << argv[0] << " -r <repl_policy> [-n <max_running_processes>]\n";
+        std::cerr << "    repl_policy: LRU LFU SRRIP\n";
+        std::cerr << "    (optional) max_running_processes: >= 1 (set to 1 by default)\n";
+        exit(1);
+    }
+
+    // Define benchmarks
+    const char *PARSEC_benchmarks[] = {"blackscholes", "bodytrack", "canneal", "dedup", "fluidanimate", "freqmine", "streamcluster", "swaptions", "x264"};
+    const char *SPEC_benchmarks[] = {"bzip2", "gcc", "mcf", "hmmer", "sjeng", "libquantum", "xalancbmk", "milc", "cactusADM", "leslie3d", "namd", "soplex", "calculix", "lbm"};
+    int num_PARSEC_benchmarks = sizeof(PARSEC_benchmarks) / sizeof(PARSEC_benchmarks[0]);
+    int num_SPEC_benchmarks = sizeof(SPEC_benchmarks) / sizeof(SPEC_benchmarks[0]);
+
+    // Run LRU benchmarks
+    std::cout << "--------------- Starting " << repl_policy << " child processes -----------------" << std::endl;
+    std::cout << std::endl;
+
+    std::unordered_map<pid_t, const char *> pid_benchmark_map;
+    std::vector<pid_t> child_pids;
+
+    // create and stop the child processes
+    std::cout << "STARTING and STOPPING all PARSEC benchmarks on replacement policy: " << repl_policy << std::endl;
+    start_stop_processes(child_pids, pid_benchmark_map,
+                         PARSEC_benchmarks, num_PARSEC_benchmarks,
+                         const_cast<char *>("PARSEC"), repl_policy);
+    std::cout << "STOPPED all PARSEC benchmarks on replacement policy: " << repl_policy << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "STARTING and STOPPING all SPEC benchmarks on replacement policy: " << repl_policy << std::endl;
+    start_stop_processes(child_pids, pid_benchmark_map,
+                         SPEC_benchmarks, num_SPEC_benchmarks,
+                         const_cast<char *>("SPEC"), repl_policy);
+    std::cout << "STOPPED all SPEC benchmarks on replacement policy: " << repl_policy << std::endl;
+    std::cout << std::endl;
+
+    // restart the child processes in a controlled manner
+    std::cout << "RUNNING benchmarks in a controlled manner according to MAX_RUNNING_PROCESSES: ";
+    std::cout << MAX_RUNNING_PROCESSES << std::endl;
+    restart_processes(child_pids, pid_benchmark_map);
+
+    std::cout << std::endl;
+    std::cout << "--------------- Finished " << repl_policy << " child processes -----------------" << std::endl;
+
+    return 0;
+}

--- a/zsim/hw4runscript
+++ b/zsim/hw4runscript
@@ -15,12 +15,12 @@ else
     # your simulation results will be saved to outputs/hw4/$repl/$bench/
     if [ "$suite" = "SPEC" ]; then
         mkdir -p outputs/hw4/$repl/${bench}
-        echo "./build/opt/zsim configs/hw4/$repl/${bench}.cfg > outputs/hw4/$repl/${bench}/${bench}.log 2>&1 &"
-        ./build/opt/zsim configs/hw4/$repl/${bench}.cfg > outputs/hw4/$repl/${bench}/${bench}.log 2>&1 &
+        echo "./build/opt/zsim configs/hw4/$repl/${bench}.cfg > outputs/hw4/$repl/${bench}/${bench}.log 2>&1"
+        ./build/opt/zsim configs/hw4/$repl/${bench}.cfg > outputs/hw4/$repl/${bench}/${bench}.log 2>&1 
     elif [ "$suite" = "PARSEC" ]; then
         mkdir -p outputs/hw4/$repl/${bench}_8c_simlarge
-        echo "./build/opt/zsim configs/hw4/$repl/${bench}_8c_simlarge.cfg > outputs/hw4/$repl/${bench}_8c_simlarge/${bench}.log 2>&1 &"
-        ./build/opt/zsim configs/hw4/$repl/${bench}_8c_simlarge.cfg > outputs/hw4/$repl/${bench}_8c_simlarge/${bench}.log 2>&1 &
+        echo "./build/opt/zsim configs/hw4/$repl/${bench}_8c_simlarge.cfg > outputs/hw4/$repl/${bench}_8c_simlarge/${bench}.log 2>&1"
+        ./build/opt/zsim configs/hw4/$repl/${bench}_8c_simlarge.cfg > outputs/hw4/$repl/${bench}_8c_simlarge/${bench}.log 2>&1
     else
         echo "No such benchmark suite, please specify SPEC or PARSEC"
     fi


### PR DESCRIPTION
Added an automated script, `hw4runpolicy.cpp`, that will run all the benchmarks for a specified replacement policy. Also added are updates to the `README.md` so that students can easily understand how to use the two different run programs.

The `hw4runpolicy.cpp` is a .cpp program that tests a single replacement policy on all the benchmarks required for the homework. The correct usage of the file is as follows:
```
$ g++ -std=c++17 -Wall -Wextra -Wpedantic -o hw4runpolicy.o hw4runpolicy.cpp
$ ./hw4runpolicy.o -r <repl_policy> [-n <max_running_processes>] &
```
where
```
repl_policy: LRU LFU SRRIP
(optional) max_running_processes: >= 1 (set to 1 by default)
```